### PR TITLE
pzrt4-code-addition

### DIFF
--- a/setters.js
+++ b/setters.js
@@ -17,3 +17,5 @@ const robot = {
     }
   }
 };
+
+robot.numOfSensors = 100;


### PR DESCRIPTION
the numOfSensors() setter method was used to assign the _numOfSensors property a value of 100 (a valid value).